### PR TITLE
Controversial lifetime simplifications

### DIFF
--- a/src/jsonpath.rs
+++ b/src/jsonpath.rs
@@ -18,6 +18,6 @@ impl std::fmt::Display for SyntaxError {
     }
 }
 
-pub fn parse<'a>(selector: &'a str) -> Result<Box<dyn Path + 'a>, SyntaxError> {
+pub fn parse(selector: &str) -> Result<Box<dyn Path + '_>, SyntaxError> {
     parser::parse(selector).map_err(|m| SyntaxError { message: m })
 }

--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -23,7 +23,7 @@ pub trait Matcher {
 pub struct RootSelector {}
 
 impl Matcher for RootSelector {
-    fn select<'a>(&'a self, node: &'a Value) -> Iter<'a> {
+    fn select<'a>(&self, node: &'a Value) -> Iter<'a> {
         Box::new(iter::once(node))
     }
 }
@@ -53,7 +53,7 @@ impl Child {
 }
 
 impl Matcher for Child {
-    fn select<'a>(&'a self, node: &'a Value) -> Iter<'a> {
+    fn select<'a>(&self, node: &'a Value) -> Iter<'a> {
         Box::new(node.get(&self.name).into_iter())
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::pest::Parser;
 #[grammar = "grammar.pest"]
 struct PathParser;
 
-pub fn parse<'a>(selector: &'a str) -> Result<Box<dyn path::Path + 'a>, String> {
+pub fn parse(selector: &str) -> Result<Box<dyn path::Path + '_>, String> {
     let selector_rule = PathParser::parse(Rule::selector, selector)
         .map_err(|e| format!("{}", e))?
         .next()

--- a/src/path.rs
+++ b/src/path.rs
@@ -19,7 +19,7 @@ struct SelectorPath {
     matchers: Vec<Box<dyn matchers::Matcher>>,
 }
 
-pub fn new<'a>(matchers: Vec<Box<dyn matchers::Matcher>>) -> impl Path + 'a {
+pub fn new(matchers: Vec<Box<dyn matchers::Matcher>>) -> impl Path {
     SelectorPath { matchers }
 }
 


### PR DESCRIPTION
I'm more than half way through the rust book and according to the lifetime elision rules described there
we could simplify some of the signatures.

While on one hand being explicit is good, there is an argument in favour of simplifying when possible:
adding unnecessary annotations (lifetime or type decls) is bound to draw some attention when the next
developer reads the code; they might pause to think why would that be necessary and it might thus cause distraction.