### PR TITLE
Implement wildcard matcher for arrays

### DIFF
--- a/tests/cts.json
+++ b/tests/cts.json
@@ -37,7 +37,7 @@
     "name": "wildcarded child of array",
     "selector": "$.*",
     "document": ["first", "second"],
-    "result": []
+    "result": ["first", "second"]
   }, {
     "name": "wildcarded child dot child",
     "selector": "$.*.a",


### PR DESCRIPTION
Spec https://jsonpath-standard.github.io/internet-draft/#section-2.6.1

```
A dot child name consisting of a single asterisk is a wild card. It selects all the values of any object node. It also selects all the elements of any array node. It selects no nodes from number, string, or literal nodes.
```