### PR TITLE
Avoid using dyn Path when not necessary

### DIFF
--- a/src/jsonpath.rs
+++ b/src/jsonpath.rs
@@ -18,6 +18,6 @@ impl std::fmt::Display for SyntaxError {
     }
 }
 
-pub fn parse(selector: &str) -> Result<Box<dyn Path + '_>, SyntaxError> {
+pub fn parse(selector: &str) -> Result<impl Path, SyntaxError> {
     parser::parse(selector).map_err(|m| SyntaxError { message: m })
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::pest::Parser;
 #[grammar = "grammar.pest"]
 struct PathParser;
 
-pub fn parse(selector: &str) -> Result<Box<dyn path::Path + '_>, String> {
+pub fn parse(selector: &str) -> Result<impl path::Path, String> {
     let selector_rule = PathParser::parse(Rule::selector, selector)
         .map_err(|e| format!("{}", e))?
         .next()
@@ -33,7 +33,7 @@ pub fn parse(selector: &str) -> Result<Box<dyn path::Path + '_>, String> {
         }
     }
 
-    Ok(Box::new(path::new(ms)))
+    Ok(path::new(ms))
 }
 
 fn parse_matcher(matcher_rule: pest::iterators::Pair<Rule>) -> Vec<Box<dyn matchers::Matcher>> {

--- a/tests/cts.rs
+++ b/tests/cts.rs
@@ -6,7 +6,7 @@
 
 #[cfg(test)]
 mod tests {
-    use jsonpath_reference_implementation::jsonpath;
+    use jsonpath_reference_implementation::{jsonpath, path::Path as _};
     use serde::{Deserialize, Serialize};
     use std::fs;
     use std::panic;


### PR DESCRIPTION
Advantage: call to the

Disadvantage: callers need to  bring path::Path explicitly in scope.

This seems to be more idiomatic rust code, at least from what I understand
reading https://rust-lang.github.io/rfcs/2113-dyn-trait-syntax.html