### PR TITLE
Use zip and find_map to unescape

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -123,11 +123,15 @@ fn unescape(contents: &str) -> String {
 
                 i += 4;
             } else {
-                for (j, c) in ESCAPED.chars().enumerate() {
-                    if xs[i] == c {
-                        output.push(UNESCAPED.chars().nth(j).unwrap())
+                let u = ESCAPED.chars().zip(UNESCAPED.chars()).find_map(|(e, u)| {
+                    if xs[i] == e {
+                        Some(u)
+                    } else {
+                        None
                     }
-                }
+                });
+                output.push(u.unwrap());
+
                 i += 1;
             }
         } else {


### PR DESCRIPTION
This is possibly more elegant and also more robust as it panics if the escape sequence is not recognized.

That said, we apply our tests against the parser (I have a PR with a unit test for this unescape
but I realized it might be better to capture the test in the parser layer so it can be shared with
other implementations).