### PR TITLE
Allow lints of pest grammar terminals

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -85,4 +85,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: -- -D warnings -A clippy::upper-case-acronyms


### PR DESCRIPTION
Terminals such as EOI and WHITESPACE are objected to by clippy.