### PR TITLE
Bump edition

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [ stable, "1.43.0" ]
+        toolchain: [ stable ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [ stable, "1.43.0" ]
+        toolchain: [ stable ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -1,8 +1,4 @@
 # Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
-#
-# While our "example" application has the platform-specific code,
-# for simplicity we are compiling and testing everything on the Ubuntu environment only.
-# For multi-OS testing see the `cross.yml` workflow.
 
 on: [push, pull_request]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jsonpath_reference_implementation"
 version = "0.0.1"
 authors = ["Glyn Normington <glyn.normington@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 itertools = "0.9.0"


### PR DESCRIPTION
The purpose of this PR is simply to keep up to date with modern Rust.

Thanks to @cburgmer's observation in https://github.com/jsonpath-standard/jsonpath-reference-implementation/pull/29, we no longer need to support Rust 1.43.0.